### PR TITLE
Update quick-xml to 0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/spsheet"
 chrono = { version = "~0.4.0" }
 era-jp = { version = "~0.1.1" }
 nom = { version = "~3.2.1" }
-quick-xml = { version = "~0.10.1", optional = true }
+quick-xml = { version = "~0.15.0", optional = true }
 tempdir = { version = "~0.3.5", optional = true }
 time = { version = "~0.1.38", optional = true }
 walkdir = { version = "~2.0.1", optional = true }

--- a/src/file_common.rs
+++ b/src/file_common.rs
@@ -1,24 +1,23 @@
+extern crate quick_xml;
 extern crate tempdir;
 extern crate walkdir;
 extern crate zip;
-extern crate quick_xml;
 
 use self::quick_xml::events::attributes::Attribute;
-use self::quick_xml::events::{Event, BytesEnd, BytesStart, BytesText};
-use self::quick_xml::writer::Writer;
-use self::zip::write::FileOptions;
-use self::walkdir::WalkDir;
+use self::quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
+use self::quick_xml::Writer;
 use self::tempdir::TempDir;
+use self::walkdir::WalkDir;
+use self::zip::write::FileOptions;
 use std::borrow::Cow;
-use std::fs::File;
 use std::fs;
+use std::fs::File;
 use std::io;
-use std::io::{Write,Read,Cursor};
+use std::io::{Cursor, Read, Write};
 use std::path::Path;
 use std::string::FromUtf8Error;
 
-pub fn write_to_file(path: &Path, dir: &TempDir) -> Result<(), io::Error>
-{
+pub fn write_to_file(path: &Path, dir: &TempDir) -> Result<(), io::Error> {
     let file = File::create(&path)?;
     let mut zip = zip::ZipWriter::new(file);
     let options = FileOptions::default()
@@ -29,11 +28,11 @@ pub fn write_to_file(path: &Path, dir: &TempDir) -> Result<(), io::Error>
 
     for dent in it.filter_map(|e| e.ok()) {
         let path = dent.path();
-        let name = path.strip_prefix(Path::new(dir.path()))
+        let name = path
+            .strip_prefix(Path::new(dir.path()))
             .unwrap()
             .to_str()
             .unwrap();
-
 
         if path.is_file() {
             //println!("adding {:?} as {:?} ...", path, name);
@@ -56,8 +55,7 @@ pub fn write_to_file(path: &Path, dir: &TempDir) -> Result<(), io::Error>
     Ok(())
 }
 
-pub fn unzip(zip_file: &File, dir: &TempDir) -> Result<(), zip::result::ZipError> 
-{
+pub fn unzip(zip_file: &File, dir: &TempDir) -> Result<(), zip::result::ZipError> {
     let mut zip = zip::ZipArchive::new(zip_file)?;
     for i in 0..zip.len() {
         let mut file = zip.by_index(i)?;
@@ -75,13 +73,17 @@ pub fn unzip(zip_file: &File, dir: &TempDir) -> Result<(), zip::result::ZipError
     Ok(())
 }
 
-pub fn make_static_file(temp_dir: &TempDir, path: &str, data: &str, dir: Option<&str>) -> Result<(), io::Error>
-{
+pub fn make_static_file(
+    temp_dir: &TempDir,
+    path: &str,
+    data: &str,
+    dir: Option<&str>,
+) -> Result<(), io::Error> {
     match dir {
         Some(dir) => {
             let dir_path = temp_dir.path().join(dir);
             fs::create_dir_all(dir_path)?;
-        },
+        }
         None => {}
     }
     let file_path = temp_dir.path().join(path);
@@ -91,8 +93,13 @@ pub fn make_static_file(temp_dir: &TempDir, path: &str, data: &str, dir: Option<
     Ok(())
 }
 
-pub fn write_start_tag<'a, S>(writer: &mut Writer<Cursor<Vec<u8>>>, tag_name: S, attributes: Vec<(&str, &str)>, empty_flag: bool) 
-    where S: Into<Cow<'a, str>>
+pub fn write_start_tag<'a, S>(
+    writer: &mut Writer<Cursor<Vec<u8>>>,
+    tag_name: S,
+    attributes: Vec<(&str, &str)>,
+    empty_flag: bool,
+) where
+    S: Into<Cow<'a, str>>,
 {
     let tag_name = tag_name.into();
     let mut elem = BytesStart::owned(tag_name.as_bytes().to_vec(), tag_name.len());
@@ -106,24 +113,31 @@ pub fn write_start_tag<'a, S>(writer: &mut Writer<Cursor<Vec<u8>>>, tag_name: S,
     }
 }
 
-pub fn write_end_tag<'a, S>(writer: &mut Writer<Cursor<Vec<u8>>>, tag_name: S) 
-     where S: Into<Cow<'a, str>>
+pub fn write_end_tag<'a, S>(writer: &mut Writer<Cursor<Vec<u8>>>, tag_name: S)
+where
+    S: Into<Cow<'a, str>>,
 {
-   let _ = writer.write_event(Event::End(BytesEnd::borrowed(tag_name.into().as_bytes())));
+    let _ = writer.write_event(Event::End(BytesEnd::borrowed(tag_name.into().as_bytes())));
 }
 
-pub fn write_text_node<'a, S>(writer: &mut Writer<Cursor<Vec<u8>>>, data: S) 
-    where S: Into<Cow<'a, str>>
+pub fn write_text_node<'a, S>(writer: &mut Writer<Cursor<Vec<u8>>>, data: S)
+where
+    S: Into<Cow<'a, str>>,
 {
-   let _ = writer.write_event(Event::Text(BytesText::borrowed(data.into().as_bytes())));
+    let _ = writer.write_event(Event::Text(BytesText::from_plain_str(&data.into())));
 }
 
-pub fn make_file_from_writer(path: &str, temp_dir: &TempDir, writer: Writer<Cursor<Vec<u8>>>, dir: Option<&str>) -> Result<(), io::Error> {
+pub fn make_file_from_writer(
+    path: &str,
+    temp_dir: &TempDir,
+    writer: Writer<Cursor<Vec<u8>>>,
+    dir: Option<&str>,
+) -> Result<(), io::Error> {
     match dir {
         Some(dir) => {
             let dir_path = temp_dir.path().join(dir);
             fs::create_dir_all(dir_path)?;
-        },
+        }
         None => {}
     }
     let file_path = temp_dir.path().join(path);
@@ -139,10 +153,9 @@ pub fn get_attribute_value(attr: &Attribute) -> Result<String, FromUtf8Error> {
 }
 
 pub fn condvert_character_reference(src: &str) -> String {
-    src.
-        replace("&amp;", "&").
-        replace("&lt;", "<").
-        replace("&gt;", ">").
-        replace("&quot;", "\"").
-        replace("&apos;", "'")
+    src.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
 }

--- a/src/ods/mod.rs
+++ b/src/ods/mod.rs
@@ -3,20 +3,20 @@ extern crate quick_xml;
 extern crate tempdir;
 extern crate zip;
 
-use super::{Book,Sheet,Cell,Value};
-use std::path::Path;
+use self::quick_xml::events::{BytesStart, Event};
+use self::quick_xml::Reader;
 use self::tempdir::TempDir;
-use std::io;
-use std::result;
-use self::quick_xml::reader::Reader;
-use self::quick_xml::events::{Event, BytesStart};
-use std::fs::File;
-use std::string::FromUtf8Error;
+use super::{Book, Cell, Sheet, Value};
 use file_common::*;
+use std::fs::File;
+use std::io;
 use std::io::BufReader;
+use std::path::Path;
+use std::result;
+use std::string::FromUtf8Error;
 
-mod read_style;
 mod read_content;
+mod read_style;
 mod write_content;
 mod write_style;
 
@@ -35,7 +35,7 @@ const MANIFEST_XML_CONTENT: &'static str = r#"<?xml version="1.0" encoding="UTF-
 #[derive(Debug)]
 pub enum OdsError {
     Io(io::Error),
-    Xml(quick_xml::errors::Error),
+    Xml(quick_xml::Error),
     Zip(zip::result::ZipError),
     Uft8(FromUtf8Error),
 }
@@ -46,8 +46,8 @@ impl From<io::Error> for OdsError {
     }
 }
 
-impl From<quick_xml::errors::Error> for OdsError {
-    fn from(err: quick_xml::errors::Error) -> OdsError {
+impl From<quick_xml::Error> for OdsError {
+    fn from(err: quick_xml::Error) -> OdsError {
         OdsError::Xml(err)
     }
 }
@@ -70,7 +70,7 @@ pub fn read(path: &Path) -> Result<Book> {
     let file = File::open(path)?;
     let dir = TempDir::new("shreadsheet")?;
     match unzip(&file, &dir) {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(err) => {
             dir.close()?;
             return Err(OdsError::Zip(err));
@@ -87,23 +87,29 @@ pub fn write(book: &Book, path: &Path) -> result::Result<(), OdsError> {
     let _ = write_style::write(book, &dir);
     let _ = write_content::write(book, &dir);
     let _ = make_static_file(
-        &dir, "META-INF/manifest.xml", 
-        MANIFEST_XML_CONTENT, 
-        Some("META-INF"))?;
+        &dir,
+        "META-INF/manifest.xml",
+        MANIFEST_XML_CONTENT,
+        Some("META-INF"),
+    )?;
     write_to_file(path, &dir)?;
     dir.close()?;
     Ok(())
 }
 
-fn read_number_format(e: &BytesStart, long_value: &str, short_value: &str) -> result::Result<String, OdsError> {
+fn read_number_format(
+    e: &BytesStart,
+    long_value: &str,
+    short_value: &str,
+) -> result::Result<String, OdsError> {
     let mut number_style = String::from("");
     for a in e.attributes().with_checks(false) {
         match a {
             Ok(ref attr) if attr.key == b"number:style" => {
                 number_style = get_attribute_value(attr)?;
-            },
-            Ok(_) => {},
-            Err(_) => {},
+            }
+            Ok(_) => {}
+            Err(_) => {}
         }
     }
     Ok(String::from(if number_style == "long" {
@@ -120,51 +126,51 @@ fn read_number_year(e: &BytesStart) -> result::Result<String, OdsError> {
         match a {
             Ok(ref attr) if attr.key == b"number:style" => {
                 number_style = get_attribute_value(attr)?;
-            },
+            }
             Ok(ref attr) if attr.key == b"number:calendar" => {
                 number_calendar = get_attribute_value(attr)?;
-            },
-            Ok(_) => {},
-            Err(_) => {},
+            }
+            Ok(_) => {}
+            Err(_) => {}
         }
     }
-    Ok(String::from(if number_style == "long" && number_calendar == "gengou" {
-        "EE"
-    } else if number_calendar == "gengou" {
-        "E"
-    } else if number_style == "long" {
-        "YYYY"
-    } else {
-        "YY"
-    }))
+    Ok(String::from(
+        if number_style == "long" && number_calendar == "gengou" {
+            "EE"
+        } else if number_calendar == "gengou" {
+            "E"
+        } else if number_style == "long" {
+            "YYYY"
+        } else {
+            "YY"
+        },
+    ))
 }
 
-fn read_number_date_style(reader: &mut Reader<BufReader<File>>) -> result::Result<String, OdsError> {
+fn read_number_date_style(
+    reader: &mut Reader<BufReader<File>>,
+) -> result::Result<String, OdsError> {
     let mut buf = Vec::new();
     let mut style_format = String::from("");
     let mut text_empty_flag = true;
     loop {
         match reader.read_event(&mut buf) {
-            Ok(Event::Start(ref e)) => {
-                match e.name() {
-                    b"number:text" => {
-                        text_empty_flag = true;
-                    },
-                    _ => (),
+            Ok(Event::Start(ref e)) => match e.name() {
+                b"number:text" => {
+                    text_empty_flag = true;
                 }
+                _ => (),
             },
-            Ok(Event::End(ref e)) => {
-                match e.name() {
-                    b"number:text" => {
-                        if text_empty_flag {
-                            style_format.push_str("\\ ");
-                        }
-                    },
-                    b"number:date-style" => {
-                        return Ok(style_format);
-                    },
-                    _ => (),
+            Ok(Event::End(ref e)) => match e.name() {
+                b"number:text" => {
+                    if text_empty_flag {
+                        style_format.push_str("\\ ");
+                    }
                 }
+                b"number:date-style" => {
+                    return Ok(style_format);
+                }
+                _ => (),
             },
             Ok(Event::Empty(ref e)) => {
                 let added_string = match e.name() {
@@ -178,7 +184,7 @@ fn read_number_date_style(reader: &mut Reader<BufReader<File>>) -> result::Resul
                     _ => Ok(String::from("")),
                 };
                 style_format.push_str(added_string?.as_str());
-            },
+            }
             Ok(Event::Text(e)) => {
                 match e.unescape_and_decode(&reader).unwrap().as_str() {
                     "/" => style_format.push_str("/"),
@@ -195,7 +201,7 @@ fn read_number_date_style(reader: &mut Reader<BufReader<File>>) -> result::Resul
                     }
                 }
                 text_empty_flag = false;
-            },
+            }
             Ok(Event::Eof) => break,
             Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
             _ => (),

--- a/src/ods/read_content.rs
+++ b/src/ods/read_content.rs
@@ -1,6 +1,6 @@
 use super::{Book,Sheet,Cell};
 use file_common::*;
-use super::quick_xml::reader::Reader;
+use super::quick_xml::Reader;
 use super::quick_xml::events::{Event};
 use super::tempdir::TempDir;
 use super::{Result};
@@ -70,7 +70,7 @@ pub fn read(dir: &TempDir, style_content: &StyleContent) -> Result<Book> {
                             match a {
                                 Ok(ref attr) if attr.key == b"style:name" => {
                                     date_style_map.insert(
-                                        get_attribute_value(attr)?, 
+                                        get_attribute_value(attr)?,
                                         super::read_number_date_style(&mut reader)?);
                                 },
                                 Ok(_) => {},

--- a/src/ods/read_style.rs
+++ b/src/ods/read_style.rs
@@ -1,5 +1,5 @@
 use file_common::*;
-use super::quick_xml::reader::Reader;
+use super::quick_xml::Reader;
 use super::quick_xml::events::{Event};
 use super::tempdir::TempDir;
 use std::collections::HashMap;
@@ -14,7 +14,7 @@ pub struct StyleContent {
 
 pub fn read(dir: &TempDir) -> Result<StyleContent, OdsError> {
     let mut date_style_map = HashMap::new();
-    
+
     let path = dir.path().join(STYLES_XML);
     let mut reader = Reader::from_file(path)?;
 
@@ -29,7 +29,7 @@ pub fn read(dir: &TempDir) -> Result<StyleContent, OdsError> {
                             match a {
                                 Ok(ref attr) if attr.key == b"style:name" => {
                                     date_style_map.insert(
-                                        get_attribute_value(attr)?, 
+                                        get_attribute_value(attr)?,
                                         super::read_number_date_style(&mut reader)?);
                                 },
                                 Ok(_) => {},

--- a/src/ods/write_content.rs
+++ b/src/ods/write_content.rs
@@ -3,7 +3,7 @@ use super::tempdir::TempDir;
 use std::collections::HashMap;
 use std::result;
 use super::quick_xml::events::{Event, BytesDecl};
-use super::quick_xml::writer::Writer;
+use super::quick_xml::Writer;
 use std::io::Cursor;
 use std::io::Write;
 use std::fs::File;
@@ -26,15 +26,15 @@ fn make_content_xml_table_cell(writer: &mut Writer<Cursor<Vec<u8>>>, cell: &Cell
     match cell.get_value() {
         &Value::Str(ref value) => {
             write_start_tag(writer, "table:table-cell", vec![
-                ("office:value-type", "string"), 
+                ("office:value-type", "string"),
                 ("calcext:value-type", "string")], false);
             write_start_tag(writer, "text:p", vec![], false);
             write_text_node(writer, value.to_string());
         },
         &Value::Float(ref value) => {
             write_start_tag(writer, "table:table-cell", vec![
-                ("office:value-type", "float"), 
-                ("office:value", value.to_string().as_str()), 
+                ("office:value-type", "float"),
+                ("office:value", value.to_string().as_str()),
                 ("calcext:value-type", "float")], false);
             write_start_tag(writer, "text:p", vec![], false);
             write_text_node(writer, value.to_string());
@@ -42,9 +42,9 @@ fn make_content_xml_table_cell(writer: &mut Writer<Cursor<Vec<u8>>>, cell: &Cell
         &Value::Date(ref value) => {
             let formater = cell.get_format().get_content();
             write_start_tag(writer, "table:table-cell", vec![
-                ("table:style-name", date_hash.get(formater).unwrap().as_str()), 
-                ("office:value-type", "date"), 
-                ("office:date-value", value.format("%Y-%m-%dT%H:%M:%S").to_string().as_str()), 
+                ("table:style-name", date_hash.get(formater).unwrap().as_str()),
+                ("office:value-type", "date"),
+                ("office:date-value", value.format("%Y-%m-%dT%H:%M:%S").to_string().as_str()),
                 ("calcext:value-type", "date")
             ], false);
             write_start_tag(writer, "text:p", vec![], false);
@@ -53,9 +53,9 @@ fn make_content_xml_table_cell(writer: &mut Writer<Cursor<Vec<u8>>>, cell: &Cell
         &Value::Currency(ref value) => {
             let formater = cell.get_format().get_content();
             write_start_tag(writer, "table:table-cell", vec![
-                ("table:style-name", date_hash.get(formater).unwrap().as_str()), 
-                ("office:value-type", "currency"), 
-                ("office:date-value", value.to_string().as_str()), 
+                ("table:style-name", date_hash.get(formater).unwrap().as_str()),
+                ("office:value-type", "currency"),
+                ("office:date-value", value.to_string().as_str()),
                 ("calcext:value-type", "currency")
             ], false);
             write_start_tag(writer, "text:p", vec![], false);

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -43,7 +43,7 @@ const RELS_CONTENT: &'static str = r#"<?xml version="1.0" encoding="UTF-8"?>
 #[derive(Debug)]
 pub enum XlsxError {
     Io(io::Error),
-    Xml(quick_xml::errors::Error),
+    Xml(quick_xml::Error),
     Zip(zip::result::ZipError),
     Uft8(FromUtf8Error),
 }
@@ -54,8 +54,8 @@ impl From<io::Error> for XlsxError {
     }
 }
 
-impl From<quick_xml::errors::Error> for XlsxError {
-    fn from(err: quick_xml::errors::Error) -> XlsxError {
+impl From<quick_xml::Error> for XlsxError {
+    fn from(err: quick_xml::Error) -> XlsxError {
         XlsxError::Xml(err)
     }
 }
@@ -98,9 +98,9 @@ pub fn read(path: &Path) -> Result<Book> {
             let sheet_target = rels_map.get(s.get("rid").unwrap()).unwrap();
             book.add_sheet(
                 read_sheet::read(
-                    &dir, s.get("name").unwrap(), 
-                    sheet_target, 
-                    &shared_strings, 
+                    &dir, s.get("name").unwrap(),
+                    sheet_target,
+                    &shared_strings,
                     &styles)?);
         }
     }
@@ -113,20 +113,20 @@ pub fn write(book: &Book, path: &Path) -> result::Result<(), XlsxError> {
     let now = Utc::now();
     let now_str = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
     let _ = make_static_file(
-        &dir, RELS, 
-        RELS_CONTENT, 
+        &dir, RELS,
+        RELS_CONTENT,
         Some("_rels"))?;
     let _ = make_static_file(
-        &dir, "[Content_Types].xml", 
-        CONTENT_TYPE_XML, 
+        &dir, "[Content_Types].xml",
+        CONTENT_TYPE_XML,
         None)?;
     let _ = make_static_file(
-        &dir, "docProps/app.xml", 
-        APP_XML, 
+        &dir, "docProps/app.xml",
+        APP_XML,
         Some("docProps"))?;
     let _ = make_static_file(
-        &dir, "docProps/core.xml", 
-        CORE_XML.replace("XXXXXXXXXX", now_str.as_str()).as_str(), 
+        &dir, "docProps/core.xml",
+        CORE_XML.replace("XXXXXXXXXX", now_str.as_str()).as_str(),
         Some("docProps"))?;
     let format_map = write_styles::write(book, &dir)?;
     let shared_strings = write_shared_strings::write(book, &dir)?;

--- a/src/xlsx/read_shared_strings.rs
+++ b/src/xlsx/read_shared_strings.rs
@@ -1,5 +1,5 @@
 use std::result;
-use super::quick_xml::reader::Reader;
+use super::quick_xml::Reader;
 use super::quick_xml::events::{Event};
 use super::tempdir::TempDir;
 use super::XlsxError;

--- a/src/xlsx/read_sheet.rs
+++ b/src/xlsx/read_sheet.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::result;
 use super::time::Duration;
 use super::chrono::prelude::*;
-use super::quick_xml::reader::Reader;
+use super::quick_xml::Reader;
 use super::quick_xml::events::{Event};
 use super::tempdir::TempDir;
 use super::XlsxError;
@@ -74,7 +74,7 @@ pub fn read(dir: &TempDir, name: &String, target: &String, shared_strings: &Vec<
                             match hash.get("formatCode") {
                                 Some(format_code) => {
                                     Cell::new(
-                                        Value::Date(number_to_date(&string_value)), 
+                                        Value::Date(number_to_date(&string_value)),
                                         format_code.to_string()
                                     )
                                 },

--- a/src/xlsx/read_styles.rs
+++ b/src/xlsx/read_styles.rs
@@ -1,7 +1,7 @@
 use file_common::*;
 use std::collections::HashMap;
 use std::result;
-use super::quick_xml::reader::Reader;
+use super::quick_xml::Reader;
 use super::quick_xml::events::{Event};
 use super::tempdir::TempDir;
 use super::XlsxError;

--- a/src/xlsx/read_workbook.rs
+++ b/src/xlsx/read_workbook.rs
@@ -1,7 +1,7 @@
 use file_common::*;
 use std::collections::HashMap;
 use std::result;
-use super::quick_xml::reader::Reader;
+use super::quick_xml::Reader;
 use super::quick_xml::events::{Event};
 use super::tempdir::TempDir;
 use super::XlsxError;

--- a/src/xlsx/read_workbook_xml_rels.rs
+++ b/src/xlsx/read_workbook_xml_rels.rs
@@ -1,7 +1,7 @@
 use file_common::*;
 use std::collections::HashMap;
 use std::result;
-use super::quick_xml::reader::Reader;
+use super::quick_xml::Reader;
 use super::quick_xml::events::{Event};
 use super::tempdir::TempDir;
 use super::XlsxError;

--- a/src/xlsx/write_shared_strings.rs
+++ b/src/xlsx/write_shared_strings.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::io::Cursor;
 use std::result;
 use super::quick_xml::events::{Event, BytesDecl};
-use super::quick_xml::writer::Writer;
+use super::quick_xml::Writer;
 use super::tempdir::TempDir;
 use super::{Book,Value};
 use super::XlsxError;
@@ -31,8 +31,8 @@ pub fn write(book: &Book, dir: &TempDir) -> result::Result<HashMap<String, usize
         BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_text_node(&mut writer, "\n");
     write_start_tag(&mut writer, "sst", vec![
-        ("xmlns", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"), 
-        ("count", count.to_string().as_str()), 
+        ("xmlns", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
+        ("count", count.to_string().as_str()),
         ("uniqueCount", shared_strings.len().to_string().as_str())], false);
     let mut map: HashMap<String, usize> = HashMap::new();
     let mut index = 0;

--- a/src/xlsx/write_sheet.rs
+++ b/src/xlsx/write_sheet.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use std::result;
 use super::chrono::prelude::*;
 use super::quick_xml::events::{Event, BytesDecl};
-use super::quick_xml::writer::Writer;
+use super::quick_xml::Writer;
 use super::tempdir::TempDir;
 use super::{Sheet, Value, index_to_column};
 use super::XlsxError;

--- a/src/xlsx/write_styles.rs
+++ b/src/xlsx/write_styles.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::io::Cursor;
 use std::result;
 use super::quick_xml::events::{Event, BytesDecl};
-use super::quick_xml::writer::Writer;
+use super::quick_xml::Writer;
 use super::tempdir::TempDir;
 use super::{Book, Value};
 use super::XlsxError;
@@ -102,9 +102,9 @@ pub fn write(book: &Book, dir: &TempDir) -> result::Result<HashMap<String, usize
         BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_text_node(&mut writer, "\n");
     write_start_tag(&mut writer, "styleSheet", vec![("xmlns", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),("xmlns:x14ac", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac"),("xmlns:mc", "http://schemas.openxmlformats.org/markup-compatibility/2006"),], false);
-    
+
     let num_fmts = make_num_fmts(&mut writer, book);
-    
+
     write_start_tag(&mut writer, "fonts", vec![("count", "2"),], false);
     write_start_tag(&mut writer, "font", vec![], false);
     write_start_tag(&mut writer, "sz", vec![("val", "10.0"),], false);
@@ -145,7 +145,7 @@ pub fn write(book: &Book, dir: &TempDir) -> result::Result<HashMap<String, usize
     write_start_tag(&mut writer, "dxfs", vec![("count", "0"),], false);
     write_end_tag(&mut writer, "dxfs");
     write_end_tag(&mut writer, "styleSheet");
-    
+
     let _ = make_file_from_writer(STYLE_XML, dir, writer, Some("xl"))?;
     Ok(result)
 }

--- a/src/xlsx/write_workbook.rs
+++ b/src/xlsx/write_workbook.rs
@@ -2,7 +2,7 @@ use file_common::*;
 use std::io::Cursor;
 use std::result;
 use super::quick_xml::events::{Event, BytesDecl};
-use super::quick_xml::writer::Writer;
+use super::quick_xml::Writer;
 use super::tempdir::TempDir;
 use super::{Book};
 use super::XlsxError;

--- a/src/xlsx/write_workbook_xml_rels.rs
+++ b/src/xlsx/write_workbook_xml_rels.rs
@@ -2,7 +2,7 @@ use file_common::*;
 use std::io::Cursor;
 use std::result;
 use super::quick_xml::events::{Event, BytesDecl};
-use super::quick_xml::writer::Writer;
+use super::quick_xml::Writer;
 use super::tempdir::TempDir;
 use super::{Book};
 use super::XlsxError;


### PR DESCRIPTION
I noticed using Cell::str does not properly escape the strings, so you can end up with broken XMLs in the XLSX and ODS files. So I updated quick-xml to the latest version which has a better designed API which clarifies when it talks about escaped and plain values. This fixes the issue.